### PR TITLE
neon: Add option to disable mark as read timeout in news

### DIFF
--- a/packages/neon/lib/l10n/en.arb
+++ b/packages/neon/lib/l10n/en.arb
@@ -231,6 +231,7 @@
   "newsOptionsArticleViewTypeDirect": "Show text directly",
   "newsOptionsArticleViewTypeInternalBrowser": "Open in internal browser",
   "newsOptionsArticleViewTypeExternalBrowser": "Open in external browser",
+  "newsOptionsArticleDisableMarkAsReadTimeout": "Mark articles as read instantly",
   "newsOptionsDefaultArticlesFilter": "Articles to show by default",
   "newsOptionsArticlesSortProperty": "How to sort articles",
   "newsOptionsArticlesSortPropertyPublishDate": "Publish date",

--- a/packages/neon/lib/l10n/localizations.dart
+++ b/packages/neon/lib/l10n/localizations.dart
@@ -857,6 +857,12 @@ abstract class AppLocalizations {
   /// **'Open in external browser'**
   String get newsOptionsArticleViewTypeExternalBrowser;
 
+  /// No description provided for @newsOptionsArticleDisableMarkAsReadTimeout.
+  ///
+  /// In en, this message translates to:
+  /// **'Mark articles as read instantly'**
+  String get newsOptionsArticleDisableMarkAsReadTimeout;
+
   /// No description provided for @newsOptionsDefaultArticlesFilter.
   ///
   /// In en, this message translates to:

--- a/packages/neon/lib/l10n/localizations_en.dart
+++ b/packages/neon/lib/l10n/localizations_en.dart
@@ -420,6 +420,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get newsOptionsArticleViewTypeExternalBrowser => 'Open in external browser';
 
   @override
+  String get newsOptionsArticleDisableMarkAsReadTimeout => 'Mark articles as read instantly';
+
+  @override
   String get newsOptionsDefaultArticlesFilter => 'Articles to show by default';
 
   @override

--- a/packages/neon/lib/src/apps/news/options.dart
+++ b/packages/neon/lib/src/apps/news/options.dart
@@ -11,6 +11,7 @@ class NewsAppSpecificOptions extends NextcloudAppSpecificOptions {
     super.options = [
       defaultCategoryOption,
       articleViewTypeOption,
+      articleDisableMarkAsReadTimeoutOption,
       defaultArticlesFilterOption,
       articlesSortPropertyOption,
       articlesSortBoxOrderOption,
@@ -70,6 +71,14 @@ class NewsAppSpecificOptions extends NextcloudAppSpecificOptions {
     label: (final context) => AppLocalizations.of(context).newsOptionsArticleViewType,
     defaultValue: BehaviorSubject.seeded(ArticleViewType.direct),
     values: _articleViewTypeValuesSubject,
+  );
+
+  late final articleDisableMarkAsReadTimeoutOption = ToggleOption(
+    storage: super.storage,
+    category: articlesCategory,
+    key: 'article-disable-mark-as-read-timeout',
+    label: (final context) => AppLocalizations.of(context).newsOptionsArticleDisableMarkAsReadTimeout,
+    defaultValue: BehaviorSubject.seeded(false),
   );
 
   late final defaultArticlesFilterOption = SelectOption<FilterType>(

--- a/packages/neon/lib/src/apps/news/pages/article.dart
+++ b/packages/neon/lib/src/apps/news/pages/article.dart
@@ -57,11 +57,15 @@ class _NewsArticlePageState extends State<NewsArticlePage> {
 
   void _startMarkAsReadTimer() {
     if (article.unread!) {
-      _markAsReadTimer = Timer(const Duration(seconds: 3), () {
-        if (article.unread!) {
-          widget.bloc.markArticleAsRead(article);
-        }
-      });
+      if (widget.bloc.newsBloc.options.articleDisableMarkAsReadTimeoutOption.value) {
+        widget.bloc.markArticleAsRead(article);
+      } else {
+        _markAsReadTimer = Timer(const Duration(seconds: 3), () {
+          if (article.unread!) {
+            widget.bloc.markArticleAsRead(article);
+          }
+        });
+      }
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/jld3103/nextcloud-neon/issues/17