### PR TITLE
dynamite, neon, nextcloud: nullaware spreads (codestyle)

### DIFF
--- a/packages/dynamite/lib/src/openapi_builder.dart
+++ b/packages/dynamite/lib/src/openapi_builder.dart
@@ -33,9 +33,7 @@ class OpenAPIBuilder implements Builder {
         if (spec.paths != null) ...{
           for (final pathItem in spec.paths!.values) ...{
             for (final operation in pathItem.operations.values) ...{
-              if (operation.tags != null) ...{
-                ...operation.tags!,
-              },
+              ...?operation.tags,
             },
           },
         },
@@ -518,9 +516,7 @@ class OpenAPIBuilder implements Builder {
                         ])
                         ..body = const Code('''
                         this.baseHeaders = {
-                          if (baseHeaders != null) ...{
-                            ...baseHeaders,
-                          },
+                          ...?baseHeaders,
                         };
                         this.httpClient = (httpClient ?? HttpClient())..userAgent = userAgent;
                       '''),
@@ -670,12 +666,7 @@ class OpenAPIBuilder implements Builder {
 
                             final acceptHeader = operation.responses?.values
                                 .map((final response) => response.content?.keys)
-                                .reduce(
-                                  (final a, final b) => [
-                                    ...a ?? [],
-                                    ...b ?? [],
-                                  ],
-                                )
+                                .reduce((final a, final b) => [...?a, ...?b])
                                 ?.toSet()
                                 .join(',');
                             final code = StringBuffer('''

--- a/packages/neon/neon/lib/src/widgets/list_view.dart
+++ b/packages/neon/neon/lib/src/widgets/list_view.dart
@@ -29,9 +29,7 @@ class NeonListView<T> extends StatelessWidget {
         onRefresh: onRefresh,
         child: Column(
           children: [
-            if (topFixedChildren != null) ...[
-              ...topFixedChildren!,
-            ],
+            ...?topFixedChildren,
             NeonLinearProgressIndicator(
               margin: const EdgeInsets.symmetric(
                 horizontal: 10,
@@ -47,9 +45,7 @@ class NeonListView<T> extends StatelessWidget {
                   key: scrollKey != null ? PageStorageKey<String>(scrollKey!) : null,
                   padding: withFloatingActionButton ? const EdgeInsets.only(bottom: 88) : null,
                   children: [
-                    if (topScrollingChildren != null) ...[
-                      ...topScrollingChildren!,
-                    ],
+                    ...?topScrollingChildren,
                     NeonException(
                       error,
                       onRetry: onRefresh,

--- a/packages/neon/neon_notes/lib/widgets/notes_view.dart
+++ b/packages/neon/neon_notes/lib/widgets/notes_view.dart
@@ -51,12 +51,8 @@ class NotesView extends StatelessWidget {
                 scrollKey: 'notes-notes',
                 withFloatingActionButton: true,
                 items: [
-                  if (sortedFavorites != null) ...[
-                    ...sortedFavorites,
-                  ],
-                  if (sortedNonFavorites != null) ...[
-                    ...sortedNonFavorites,
-                  ],
+                  ...?sortedFavorites,
+                  ...?sortedNonFavorites,
                 ],
                 isLoading: notes.loading,
                 error: notes.error,

--- a/packages/nextcloud/lib/src/nextcloud.openapi.dart
+++ b/packages/nextcloud/lib/src/nextcloud.openapi.dart
@@ -106,9 +106,7 @@ class NextcloudClient {
     this.authentications = const [],
   }) {
     this.baseHeaders = {
-      if (baseHeaders != null) ...{
-        ...baseHeaders,
-      },
+      ...?baseHeaders,
     };
     this.httpClient = (httpClient ?? HttpClient())..userAgent = userAgent;
   }


### PR DESCRIPTION
fixes #288 

In another few places this happens we are wrapping a for loop in `if(notnull)...[ ]`.
We could also use a nullaware spread on a map like

```dart
if (items != null) ...[
  for (final item in items!) ...[
    builder(context, item),
  ],
],  
```

would become:

```dart
...?items?.map(
  (final item) => builder(context, item),
),
```

But I'm not that sure if this would help with readability especially when the for loop is big like 
https://github.com/provokateurin/nextcloud-neon/blob/86116b5b4d799b43a904a7ac1353e514960b6b94/packages/neon/neon/lib/src/pages/home.dart#L353-L409
