### PR TITLE
feat(tool): setup codecov flags configuration

### DIFF
--- a/.cspell/tools.txt
+++ b/.cspell/tools.txt
@@ -7,6 +7,7 @@ buildsystem
 buildx
 classpath
 cloc
+codecov
 commitlint
 dapplication
 dartdoc

--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -1,0 +1,38 @@
+github_checks:
+  annotations: true
+comment:
+  layout: newheader, diff, flags, files
+  require_changes: false
+  require_base: false
+  require_head: true
+  show_carryforward_flags: true
+  show_critical_paths: true
+  hide_comment_details: true
+flag_management:
+  default_rules:
+    carryforward: true
+flags:
+  dynamite:
+    paths:
+      - packages/dynamite/dynamite
+  dynamite_end_to_end_test:
+    paths:
+      - packages/dynamite/dynamite_end_to_end_test
+  dynamite_runtime:
+    paths:
+      - packages/dynamite/dynamite_runtime
+  neon_dashboard:
+    paths:
+      - packages/neon/neon_dashboard
+  neon_framework:
+    paths:
+      - packages/neon_framework
+  neon_talk:
+    paths:
+      - packages/neon/neon_talk
+  nextcloud:
+    paths:
+      - packages/nextcloud
+  sort_box:
+    paths:
+      - packages/sort_box

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -47,3 +47,12 @@ jobs:
           packages_glob="$(printf ",%s" "${packages[@]}")"
           packages_glob="${packages_glob:1}"
           MELOS_PACKAGES="$packages_glob" melos test
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }} 
+          codecov_yml_path: ./github/codecov.yaml
+          exclude: .fvm
+          fail_ci_if_error: true
+          slug: nextcloud/neon

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -9,6 +9,7 @@ If you need to add a new package to the Neon project please make sure to execute
 4. Add a Symlink to our main [license](../assets/AGPL-3.0.txt).
 5. Update [commitlint.yaml](../commitlint.yaml) by adding the new package name.
 6. Remove the package `.gitignore` (a global `.gitignore` for all packages is used instead).
+7. update codecov configuration with `./tool/update-codecov-config.sh`.
 
 ## Publishing new versions of the packages
 

--- a/melos.yaml
+++ b/melos.yaml
@@ -39,7 +39,17 @@ scripts:
     dart analyze --fatal-infos . &&
     dart run custom_lint --fatal-infos .
   test: >
-    melos exec --no-flutter --concurrency=1 --fail-fast --dir-exists=test -- "dart test --concurrency=$(nproc --all) --fail-fast" &&
-    melos exec --flutter --concurrency=1 --fail-fast --dir-exists=test -- "flutter test --concurrency=$(nproc --all)"
+    melos run test:dart &&
+    melos run test:flutter
+  test:dart: >
+    melos exec --no-flutter --concurrency=1 --fail-fast --dir-exists=test -- "
+      dart run --pause-isolates-on-exit --disable-service-auth-codes --enable-vm-service=8181 test --concurrency=$(nproc --all) --fail-fast &
+      dart pub global run coverage:collect_coverage --wait-paused --uri=http://127.0.0.1:8181/ -o coverage/coverage.json --resume-isolates --scope-output=foo
+      dart pub global run coverage:format_coverage --packages=.dart_tool/package_config.json --lcov -i coverage/coverage.json -o coverage/lcov.info
+    "
+  test:flutter: >
+    melos exec --flutter --concurrency=1 --fail-fast --dir-exists=test -- "
+      flutter test --concurrency=$(nproc --all) --coverage
+    "
   generate:neon:build_runner: melos exec --scope="neon*" --file-exists="build.yaml" -- dart run build_runner build --delete-conflicting-outputs && melos run format
   generate:neon:l10n: melos exec --flutter --dir-exists="lib/l10n" flutter gen-l10n && melos run format

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,6 +6,7 @@ environment:
 
 dev_dependencies:
   commitlint_cli: ^0.7.1
+  coverage: ^1.7.2
   fvm: ^3.0.14
   husky: ^0.1.7
   melos: ^5.1.0

--- a/tool/update-codecov-config.sh
+++ b/tool/update-codecov-config.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euxo pipefail
+cd "$(dirname "$0")/.."
+
+yq -iy "del(.flags)" .github/codecov.yaml
+
+for package in $(melos list --dir-exists=test --json | jq -c '.[]'); do
+    name=$(echo $package | jq -r '.name')
+    location=$(echo $package | jq -r '.location')
+    location=${location##"$(pwd)/"}
+    echo "$name $location"
+
+    yq -iy ".flags.$name.paths[0] = \"$location\"" .github/codecov.yaml
+done


### PR DESCRIPTION
finally closes: #910 
Sadly we need to add every package to the codecov config.
I've tested it in my fork and it works (coverage is correctly displayed in the codecov panel.
Coverage will only be added over time when each package first runs its tests.

@provokateurin did you already add the CI token to the github secrets? I don't have access to that so I couldn't check myself.