### PR TITLE
fix(neon_framework): Fix unsupported apps dialog shown even when none are unsupported

### DIFF
--- a/packages/neon_framework/lib/src/pages/home.dart
+++ b/packages/neon_framework/lib/src/pages/home.dart
@@ -50,7 +50,7 @@ class _HomePageState extends State<HomePage> {
     final maintenanceModeBloc = _accountsBloc.getMaintenanceModeBlocFor(widget.account);
 
     _versionCheckSubscription = _appsBloc.unsupportedApps.listen((unsupportedChecks) {
-      if (!mounted) {
+      if (!mounted || unsupportedChecks.isEmpty) {
         return;
       }
 


### PR DESCRIPTION
This part of the logic still needs to be in the listener.
https://github.com/nextcloud/neon/pull/2027