### PR TITLE
fix(neon_framework): Catch exceptions when parsing Expires header in RequestManager

### DIFF
--- a/packages/neon_framework/lib/src/utils/request_manager.dart
+++ b/packages/neon_framework/lib/src/utils/request_manager.dart
@@ -261,7 +261,15 @@ class CacheParameters {
   factory CacheParameters.parseHeaders(Map<String, dynamic> headers) {
     tz.TZDateTime? expiry;
     if (headers.containsKey('expires')) {
-      expiry = parseHttpDate(headers['expires']! as String);
+      try {
+        expiry = parseHttpDate(headers['expires']! as String);
+      } on FormatException catch (error, stackTrace) {
+        _log.finer(
+          'Failed to parse "Expires" header: "${headers['expires']}"',
+          error,
+          stackTrace,
+        );
+      }
     }
 
     return CacheParameters(


### PR DESCRIPTION
Saw a `Parsing timezone can not be done unambiguously.` flying by, but unfortunately there was no log which value was causing this.
If it happens we are fine to ignore it, since it's only caching that might not work as intended, but we can still log the error.