### PR TITLE
ci: Stop renovate from bumping minor and patch versions for dev_dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,24 +27,17 @@
     },
     {
       "matchManagers": ["pub"],
-      "matchDepTypes": ["dependencies"],
+      "matchDepTypes": ["dependencies", "devDependencies"],
       "matchUpdateTypes": [
         "minor",
         "patch"
       ],
       "matchCurrentVersion": "!/^0/",
-      "matchDepNames": [
-        "!example",
-        "!dynamite_end_to_end_test",
-        "!dynamite_petstore_example",
-        "!neon_lints",
-        "!nextcloud_test"
-      ],
       "enabled": false
     },
     {
       "matchManagers": ["pub"],
-      "matchDepTypes": ["dependencies"],
+      "matchDepTypes": ["dependencies", "devDependencies"],
       "matchUpdateTypes": [
         "patch"
       ],


### PR DESCRIPTION
Since we use workspace packages, everything is in a single committed pubspec.lock file. Only major versions will need manual checking as we also have the pipeline that verifies everything still works with downgraded dependencies.