### PR TITLE
chore(deps): replace flutter_markdown for flutter_markdown_plus

### DIFF
--- a/packages/neon_framework/packages/notes_app/lib/src/pages/note.dart
+++ b/packages/neon_framework/packages/notes_app/lib/src/pages/note.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:neon_framework/models.dart';
 import 'package:neon_framework/theme.dart';
 import 'package:neon_framework/utils.dart';

--- a/packages/neon_framework/packages/notes_app/pubspec.yaml
+++ b/packages/neon_framework/packages/notes_app/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
-  flutter_markdown: ^0.7.0
+  flutter_markdown_plus: ^1.0.7
   go_router: ^16.0.0
   http: ^1.2.1
   intl: ^0.20.2

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -644,14 +644,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_markdown:
+  flutter_markdown_plus:
     dependency: transitive
     description:
-      name: flutter_markdown
-      sha256: "08fb8315236099ff8e90cb87bb2b935e0a724a3af1623000a9cec930468e0f27"
+      name: flutter_markdown_plus
+      sha256: "039177906850278e8fb1cd364115ee0a46281135932fa8ecea8455522166d2de"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7+1"
+    version: "1.0.7"
   flutter_material_design_icons:
     dependency: transitive
     description:


### PR DESCRIPTION
The former has been deprecated by Google and has been deprecated for a while, flutter_markdown_plus is it's drop-in replacement.