### PR TITLE
fix(navigation): fix back gesture when settings open

### DIFF
--- a/packages/neon_framework/packages/files_app/lib/src/pages/main.dart
+++ b/packages/neon_framework/packages/files_app/lib/src/pages/main.dart
@@ -49,7 +49,8 @@ class _FilesMainPageState extends State<FilesMainPage> {
     return BackButtonListener(
       onBackButtonPressed: () async {
         final parent = uri.parent;
-        if (parent != null) {
+        final canPop = ModalRoute.of(context)?.isCurrent ?? true;
+        if (canPop && parent != null) {
           setState(() {
             uri = parent;
           });


### PR DESCRIPTION
This fixes the back gesture on Android not poping the settings page but navigating int the files page when in sub-directory.