### PR TITLE
feat(neon_framework): optimize blur hash handling for being performan…

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -4,7 +4,8 @@
   "useGitignore": true,
   "enableGlobDot": false,
   "words": [
-    "OpenAPI"
+    "OpenAPI",
+    "cacherine"
   ],
   "ignorePaths": [
     "**.svg",

--- a/packages/neon_framework/lib/blocs.dart
+++ b/packages/neon_framework/lib/blocs.dart
@@ -1,6 +1,7 @@
 export 'package:neon_framework/src/bloc/bloc.dart';
 export 'package:neon_framework/src/bloc/result.dart';
 export 'package:neon_framework/src/blocs/apps.dart';
+export 'package:neon_framework/src/blocs/blur.dart';
 export 'package:neon_framework/src/blocs/capabilities.dart';
 export 'package:neon_framework/src/blocs/references.dart';
 export 'package:neon_framework/src/blocs/timer.dart';

--- a/packages/neon_framework/lib/neon.dart
+++ b/packages/neon_framework/lib/neon.dart
@@ -11,6 +11,7 @@ import 'package:logging/logging.dart';
 import 'package:neon_framework/models.dart';
 import 'package:neon_framework/src/app.dart';
 import 'package:neon_framework/src/blocs/accounts.dart';
+import 'package:neon_framework/src/blocs/blur.dart';
 import 'package:neon_framework/src/blocs/first_launch.dart';
 import 'package:neon_framework/src/blocs/next_push.dart';
 import 'package:neon_framework/src/blocs/push_notifications.dart';
@@ -120,6 +121,8 @@ Future<void> runNeon({
     globalOptions: globalOptions,
   );
 
+  final blurBloc = BlurBloc();
+
   runApp(
     MultiProvider(
       providers: [
@@ -128,6 +131,7 @@ Future<void> runNeon({
         NeonProvider<AccountsBloc>.value(value: accountsBloc),
         NeonProvider<FirstLaunchBloc>.value(value: firstLaunchBloc),
         NeonProvider<NextPushBloc>.value(value: nextPushBloc),
+        NeonProvider<BlurBloc>.value(value: blurBloc),
         Provider<BuiltSet<AppImplementation>>(
           create: (_) => appImplementations,
           dispose: (_, appImplementations) => appImplementations.disposeAll(),

--- a/packages/neon_framework/lib/src/blocs/blur.dart
+++ b/packages/neon_framework/lib/src/blocs/blur.dart
@@ -1,0 +1,122 @@
+import 'dart:async';
+import 'dart:ui' as ui;
+
+import 'package:cacherine/cacherine.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter_blurhash/flutter_blurhash.dart';
+import 'package:logging/logging.dart';
+import 'package:neon_framework/blocs.dart';
+
+/// A bloc that manages the decoding of blur hashes into images.
+/// It uses a [compute] to offload the decoding process to a separate isolate, as it can be CPU intensive.
+/// Results are cached in a [SimpleLRUCache] so that they can be reused without re-decoding with a limit of 1000 entries.
+class BlurBloc extends Bloc {
+  final _blurHashCash = SimpleLRUCache<String, BlurHashDecodeTask>(1000);
+
+  @override
+  void dispose() {
+    _blurHashCash.clear();
+  }
+
+  @override
+  Logger get log => Logger('BlurBloc');
+
+  /// Gets the decoded image for the given [blurHash] and [size].
+  /// If the image is already cached, it returns the cached [BlurHashDecodeTask].
+  /// If the image is not cached, it creates a new [BlurHashDecodeTask] to decode the blur hash.
+  /// The result of the decoding process is stored in a [ValueNotifier] within the [BlurHashDecodeTask].
+  BlurHashDecodeTask getBlurHash(String blurHash, ui.Size size) {
+    final key = '$blurHash-${size.width}x${size.height}';
+
+    final cachedTask = _blurHashCash.get(key);
+    if (cachedTask != null) {
+      return cachedTask;
+    }
+
+    final task = BlurHashDecodeTask(blurHash: blurHash, size: size);
+    unawaited(task.execute());
+    _blurHashCash.set(key, task);
+    return task;
+  }
+}
+
+/// A task to decode a blur hash into an image. The result is stored in a [ValueNotifier].
+class BlurHashDecodeTask {
+  /// Creates a new [BlurHashDecodeTask] with the given [blurHash] and [size].
+  /// The result is stored in a [ValueNotifier] so that cashed blurs can be displayed without any flickering.
+  BlurHashDecodeTask({
+    required String blurHash,
+    required ui.Size size,
+  }) : _blurHashMeta = _BlurHashComputeTask(
+          blurHash: blurHash,
+          width: size.width.toInt(),
+          height: size.height.toInt(),
+        );
+
+  /// The blur hash to decode.
+  final _BlurHashComputeTask _blurHashMeta;
+
+  /// The result of the decoding process, stored in a [ValueNotifier] so that cashed blurs can be displayed without any flickering.
+  ValueNotifier<ui.Image?> blur = ValueNotifier<ui.Image?>(null);
+
+  /// Executes the task by computing the blur in an isolate and then decoding the resulting pixels into an image.
+  Future<void> execute() async {
+    final pixels = await _computePixels();
+
+    // We are using the scheduler to decode the image just to be on the safe side.
+    await SchedulerBinding.instance.scheduleTask(
+      () => ui.decodeImageFromPixels(
+        pixels,
+        _blurHashMeta.width,
+        _blurHashMeta.height,
+        ui.PixelFormat.rgba8888,
+        (image) => blur.value = image,
+      ),
+      Priority.animation,
+    );
+  }
+
+  /// Computes the pixels for the blur image either by using [SchedulerBinding] for web or [compute] for other platforms
+  /// to offload the decoding process to a separate isolate,
+  /// as it can be CPU intensive and we don't want to block the UI thread.
+  Future<Uint8List> _computePixels() async {
+    if (kIsWeb) {
+      return SchedulerBinding.instance.scheduleTask(
+        () => optimizedBlurHashDecode(
+          blurHash: _blurHashMeta.blurHash,
+          width: _blurHashMeta.width,
+          height: _blurHashMeta.height,
+        ),
+        Priority.animation,
+      );
+    }
+
+    return compute(
+      (blurHashMeta) => optimizedBlurHashDecode(
+        blurHash: blurHashMeta.blurHash,
+        width: blurHashMeta.width,
+        height: blurHashMeta.height,
+      ),
+      _blurHashMeta,
+    );
+  }
+}
+
+/// Helper object to carry the necessary data into the compute isolate.
+class _BlurHashComputeTask {
+  _BlurHashComputeTask({
+    required this.blurHash,
+    required this.width,
+    required this.height,
+  });
+
+  // The blur hash to decode.
+  final String blurHash;
+
+  // The width of the resulting image.
+  final int width;
+
+  // The height of the resulting image.
+  final int height;
+}

--- a/packages/neon_framework/lib/src/testing/mocks.dart
+++ b/packages/neon_framework/lib/src/testing/mocks.dart
@@ -119,3 +119,5 @@ class MockUrlLauncher extends Mock with MockPlatformInterfaceMixin implements Ur
 class MockReferencesBloc extends Mock implements ReferencesBloc {}
 
 class MockNavigatorObserver extends Mock implements NavigatorObserver {}
+
+class MockBlurBloc extends Mock implements BlurBloc {}

--- a/packages/neon_framework/lib/src/widgets/image.dart
+++ b/packages/neon_framework/lib/src/widgets/image.dart
@@ -3,14 +3,15 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_blurhash/flutter_blurhash.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
 import 'package:neon_framework/models.dart';
 import 'package:neon_framework/src/bloc/result.dart';
+import 'package:neon_framework/src/blocs/blur.dart';
 import 'package:neon_framework/src/utils/account_client_extension.dart';
 import 'package:neon_framework/src/utils/image_utils.dart';
+import 'package:neon_framework/src/utils/provider.dart';
 import 'package:neon_framework/src/utils/request_manager.dart';
 import 'package:neon_framework/src/widgets/error.dart';
 import 'package:neon_framework/src/widgets/linear_progress_indicator.dart';
@@ -108,22 +109,17 @@ class NeonImage extends StatelessWidget {
             // If the data is not UTF-8
           }
 
-          return Image.memory(
-            data,
-            height: size?.height,
-            width: size?.width,
-            fit: fit ?? BoxFit.contain,
-            gaplessPlayback: true,
-            errorBuilder: (context, error, stacktrace) => _buildError(context, error),
-          );
-        }
-
-        if (blurHash != null) {
-          return BlurHash(
-            hash: blurHash!,
-            imageFit: fit ?? BoxFit.cover,
-            decodingHeight: size?.height.toInt() ?? 32,
-            decodingWidth: size?.width.toInt() ?? 32,
+          return _buildImageWithBlur(
+            context,
+            child: Image.memory(
+              data,
+              height: size?.height,
+              width: size?.width,
+              fit: fit ?? BoxFit.contain,
+              gaplessPlayback: true,
+              errorBuilder: (context, error, stacktrace) => _buildError(context, error),
+            ),
+            isLoading: imageResult.isLoading,
           );
         }
 
@@ -131,13 +127,56 @@ class NeonImage extends StatelessWidget {
           return _buildError(context, imageResult.error);
         }
 
-        return SizedBox(
-          width: size?.width,
-          child: const NeonLinearProgressIndicator(),
+        return _buildBlur(context, isLoading: imageResult.isLoading);
+      },
+    );
+  }
+
+  /// Replacing the blurhash with the actual image leads to UI flickering when scrolling very fast.
+  /// To mitigate this, we keep the blurhash underneath the actual image.
+  Widget _buildImageWithBlur(BuildContext context, {required Widget child, bool isLoading = true}) => Stack(
+        fit: StackFit.passthrough,
+        children: [
+          _buildBlur(context, isLoading: isLoading),
+          child,
+        ],
+      );
+
+  Widget _buildBlur(BuildContext context, {bool isLoading = true}) {
+    if (blurHash == null) {
+      return _buildNoBlur(context, isLoading: isLoading);
+    }
+
+    final blurTask = NeonProvider.of<BlurBloc>(context).getBlurHash(
+      blurHash!,
+      size ?? const Size.square(32),
+    );
+
+    // [ValueListenableBuilder] is better then [FutureBuilder] here,
+    // because it allows us to update a cached blur without flickering, which is important when scrolling fast.
+    // Background is that [FutureBuilder] returns for a short moment null even if the future is already completed.
+    return ValueListenableBuilder(
+      // Key is important to ensure that we can move it without cost in the widget tree.
+      key: ValueKey('$blurHash'),
+      valueListenable: blurTask.blur,
+      builder: (context, blur, _) {
+        if (blur == null) {
+          return _buildNoBlur(context, isLoading: isLoading);
+        }
+
+        return RawImage(
+          image: blur,
         );
       },
     );
   }
+
+  Widget _buildNoBlur(BuildContext context, {bool isLoading = true}) => SizedBox(
+        width: size?.width,
+        child: NeonLinearProgressIndicator(
+          visible: isLoading,
+        ),
+      );
 
   Widget _buildError(BuildContext context, Object? error) =>
       errorBuilder?.call(context, error) ??

--- a/packages/neon_framework/packages/neon_rich_text/test/rich_objects/file_test.dart
+++ b/packages/neon_framework/packages/neon_rich_text/test/rich_objects/file_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:neon_framework/blocs.dart';
 import 'package:neon_framework/models.dart';
 import 'package:neon_framework/testing.dart';
 import 'package:neon_framework/widgets.dart';
@@ -14,6 +15,7 @@ const validBlurHash = 'LEHLk~WB2yk8pyo0adR*.7kCMdnj';
 void main() {
   late MockUrlLauncher urlLauncher;
   late Account account;
+  late BlurBloc blurBloc;
 
   setUpAll(() {
     FakeNeonStorage.setup();
@@ -25,6 +27,14 @@ void main() {
     when(() => urlLauncher.launchUrl(any(), any())).thenAnswer((_) async => true);
 
     UrlLauncherPlatform.instance = urlLauncher;
+
+    const fallbackSize = Size(100, 100);
+    registerFallbackValue(fallbackSize);
+
+    blurBloc = MockBlurBloc();
+    when(() => blurBloc.getBlurHash(validBlurHash, any())).thenReturn(
+      BlurHashDecodeTask(blurHash: validBlurHash, size: fallbackSize),
+    );
   });
 
   setUp(() {
@@ -65,6 +75,7 @@ void main() {
         TestApp(
           providers: [
             Provider<Account>.value(value: account),
+            Provider<BlurBloc>.value(value: blurBloc),
           ],
           child: NeonRichObjectFile(
             parameter: core.RichObjectParameter(
@@ -216,6 +227,7 @@ void main() {
         TestApp(
           providers: [
             Provider<Account>.value(value: account),
+            Provider<BlurBloc>.value(value: blurBloc),
           ],
           child: NeonRichObjectFile(
             parameter: core.RichObjectParameter(

--- a/packages/neon_framework/pubspec.yaml
+++ b/packages/neon_framework/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   bloc_concurrency: ^0.3.0
   built_collection: ^5.0.0
   built_value: ^8.9.0
+  cacherine: ^2.4.0
   collection: ^1.0.0
   cookie_store:
     path: ../cookie_store

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -185,6 +185,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.12.5"
+  cacherine:
+    dependency: transitive
+    description:
+      name: cacherine
+      sha256: "375bc4baca0560e92bb6ed7543742d6ec65638c4d642c1ba407d4d4bba399658"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   camera:
     dependency: transitive
     description:


### PR DESCRIPTION
This PR does multiple blur hash improvements:
* moves blur hash decoding out of the building path because it leads to UI freezes when opening a gallery with a lot of blur hashes
* it moves decoding to a separate scheduler to allow Flutter to decide when to decode
* it adds a result cache for future use to be able to reuse calculated blur hashes, this is especially important when scrolling up and down through a gallery
* fixes UI flickering when replacing blur hash with actual preview result 