### PR TITLE
ci: Hardcode renovate pub versioning to npm

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,6 +17,10 @@
   },
   "packageRules": [
     {
+      "matchDatasources": ["dart"],
+      "versioning": "npm"
+    },
+    {
       "matchManagers": ["pub"],
       "matchDatasources": ["dart-version", "flutter-version"],
       "matchUpdateTypes": [


### PR DESCRIPTION
See https://github.com/renovatebot/renovate/issues/40181.
Workaround until https://github.com/renovatebot/renovate/pull/42115 is merged.