### PR TITLE
fix(deps): Fix dynamic_color git hash

### DIFF
--- a/packages/neon_framework/pubspec.yaml
+++ b/packages/neon_framework/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
       url: https://github.com/provokateurin/flutter-packages
       path: packages/dynamic_color
       # dynamic_color/flutter_test
-      ref: faeecdf6c6b748af308c8eece8b3681c8cb6fbd8
+      ref: 94075d7ab7cdbe0b0749ed1cba049acb5f294f1f
   dynamite_runtime: ^0.5.0+1
   equatable: ^2.0.0
   file_picker: ^10.0.0

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -437,11 +437,11 @@ packages:
     dependency: transitive
     description:
       path: "packages/dynamic_color"
-      ref: faeecdf6c6b748af308c8eece8b3681c8cb6fbd8
-      resolved-ref: faeecdf6c6b748af308c8eece8b3681c8cb6fbd8
+      ref: "94075d7ab7cdbe0b0749ed1cba049acb5f294f1f"
+      resolved-ref: "94075d7ab7cdbe0b0749ed1cba049acb5f294f1f"
       url: "https://github.com/provokateurin/flutter-packages"
     source: git
-    version: "1.7.0"
+    version: "1.8.1"
   equatable:
     dependency: transitive
     description:


### PR DESCRIPTION
I force pushed the branch to fix some upcoming dependency conflicts and the old hash was lost this way: https://github.com/nextcloud/neon/actions/runs/23616396361/job/68784847427?pr=3132